### PR TITLE
add more tests for the badge component

### DIFF
--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -11,4 +11,31 @@ describe(Badge, () => {
     expect(badgeElement.className).toMatch(/rounded/);
     expect(badgeElement.className).toMatch(/gray/);
   });
+
+  it("displays as a square badge if the square variant option is passed in via props", () => {
+    render(<Badge title="test" variant="square" />);
+    const badgeElement = screen.getByText("test");
+    expect(badgeElement).toBeInTheDocument();
+    expect(badgeElement.className).toMatch(/square/);
+  });
+
+  it("displays as a the correct colour if the correct colour is passed in via props", () => {
+    render(<Badge title="test" colour="pink" />);
+    const badgeElement = screen.getByText("test");
+    expect(badgeElement).toBeInTheDocument();
+    expect(badgeElement.className).toMatch(/pink/);
+  });
+
+  it("falls back to the default colour if an invalid colour is passed in", () => {
+    render(<Badge title="test" colour="mauve" />);
+    const badgeElement = screen.getByText("test");
+    expect(badgeElement).toBeInTheDocument();
+    expect(badgeElement.className).toMatch(/gray/);
+  });
+
+  it("displays the correct title passed in", () => {
+    render(<Badge title="Badge" />);
+    const badgeElement = screen.getByText("Badge");
+    expect(badgeElement).toBeInTheDocument();
+  });
 });

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -19,7 +19,7 @@ describe(Badge, () => {
     expect(badgeElement.className).toMatch(/square/);
   });
 
-  it("displays as a the correct colour if the correct colour is passed in via props", () => {
+  it("displays as the correct colour if the correct colour is passed in via props", () => {
     render(<Badge title="test" colour="pink" />);
     const badgeElement = screen.getByText("test");
     expect(badgeElement).toBeInTheDocument();


### PR DESCRIPTION
This pull request adds new unit tests to the `Badge` component to ensure its behavior is correctly validated under various scenarios.

### Added tests for `Badge` component:

* Added a test to verify that the `Badge` displays as a square when the `square` variant is passed via props.
* Added a test to validate that the `Badge` displays the correct color when a valid `colour` prop is passed.
* Added a test to ensure the `Badge` falls back to the default color (`gray`) when an invalid `colour` prop is provided.
* Added a test to confirm that the `Badge` displays the correct title passed through the `title` prop.