### PR TITLE
minor refactor of badge logic and variable renaming

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -8,44 +8,37 @@ interface BadgeProps {
 }
 
 export default function Badge(props: BadgeProps): React.ReactNode {
-  let variant;
-  if (!props.variant || props.variant === "rounded") {
-    variant = styles.rounded;
-  } else {
-    variant = styles.square;
+  const variantClass = props.variant === "square" ? styles.square : styles.rounded;
+
+  let colourClass = styles.gray;
+
+  if (props.colour) {
+    switch (props.colour) {
+      case "red":
+        colourClass = styles.red;
+        break;
+      case "yellow":
+        colourClass = styles.yellow;
+        break;
+      case "green":
+        colourClass = styles.green;
+        break;
+      case "blue":
+        colourClass = styles.blue;
+        break;
+      case "indigo":
+        colourClass = styles.indigo;
+        break;
+      case "purple":
+        colourClass = styles.purple;
+        break;
+      case "pink":
+        colourClass = styles.pink;
+        break;
+    }
   }
 
-  let colour;
-  switch (props.colour) {
-    case "gray":
-      colour = styles.gray;
-      break;
-    case "red":
-      colour = styles.red;
-      break;
-    case "yellow":
-      colour = styles.yellow;
-      break;
-    case "green":
-      colour = styles.green;
-      break;
-    case "blue":
-      colour = styles.blue;
-      break;
-    case "indigo":
-      colour = styles.indigo;
-      break;
-    case "purple":
-      colour = styles.purple;
-      break;
-    case "pink":
-      colour = styles.pink;
-      break;
-    default:
-      colour = styles.gray;
-  }
-
-  const badgeClass = `${styles.badge} ${variant} ${colour}`;
+  const badgeClass = `${styles.badge} ${variantClass} ${colourClass}`;
 
   return <span className={badgeClass}>{props.title}</span>;
 }


### PR DESCRIPTION
This pull request refactors the `Badge` component in `src/components/Badge/Badge.tsx` to improve readability and simplify the logic for determining CSS classes. The key changes include consolidating conditional logic into more concise expressions and renaming variables for better clarity.

### Refactoring for readability and simplicity:
* Replaced the `if-else` logic for determining the variant class (`rounded` vs. `square`) with a single ternary expression, assigning the result to `variantClass`.
* Simplified the logic for determining the color class by removing redundant `switch` cases and using a single variable, `colourClass`, initialized with a default value (`styles.gray`).
* Consolidated the final `badgeClass` assignment to use the new `variantClass` and `colourClass` variables, improving clarity and reducing duplication.